### PR TITLE
changed cpucpre to cpu in the metric label name

### DIFF
--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -166,7 +166,7 @@ func (p *RangeListCountParser) Parse(file io.Reader) ([]Metric, error) {
 
 	// cpuset.cpus or cpuset.cpus.effective → "cpucore"
 	// cpuset.mems or cpuset.mems.effective → "numanode"
-	labelName := "cpucore" // Default for CPU-related metrics
+	labelName := "cpu" // Default for CPU-related metrics
 	if strings.Contains(p.MetricPrefix, "mems") {
 		labelName = "numanode"
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CPU metric label naming to use standardized conventions for improved consistency and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->