### PR TITLE
registerd cpu.pressure collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,35 @@ Collectors that are enabled by default can be disabled by providing a `--no-coll
 To enable only some specific collector(s), use `--collector.disable-defaults --collector.<name> ...`.
 
 ### Enabled by default
+
+#### Memory Collectors
 Name     | Description
 ---------|-------------
-memory.current | 
-memory.swap.current | 
-memory.high | 
-memory.pressure | 
+memory.current | Current memory usage in bytes
+memory.swap.current | Current swap usage in bytes
+memory.high | Memory usage high threshold limit in bytes
+memory.pressure | Memory pressure metrics (some, full, total, avg10, avg60, avg300)
+
+#### CPU Collectors
+Name     | Description
+---------|-------------
+cpu.pressure | CPU pressure metrics (some, full, total, avg10, avg60, avg300)
+cpu.stat | CPU statistics (usage_usec, user_usec, system_usec, nr_periods, nr_throttled, throttled_usec)
+cpuset.cpus | Number of CPUs in the cpuset
+cpuset.cpus.effective | Number of effective CPUs in the cpuset
+cpuset.mems | Number of memory nodes in the cpuset
+cpuset.mems.effective | Number of effective memory nodes in the cpuset
+
+#### I/O Collectors
+Name     | Description
+---------|-------------
+io.pressure | I/O pressure metrics (some, full, total, avg10, avg60, avg300)
+io.stat | I/O statistics per device (rbytes, wbytes, rios, wios, dbytes, dios)
 
 ### Disabled by default
 Name     | Description
 ---------|-------------
-memory.stat | 
+memory.stat | Detailed memory statistics (anon, file, kernel_stack, slab, etc.) 
 
 ## Contributing
 The code structure of cgroupv2_exporter is taken from [node_exporter](https://github.com/prometheus/node_exporter) and hence adding more collectors is also similar (see [collector](/collector) package).

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -276,6 +276,7 @@ func init() {
 	registerCollector("memory.swap.current", defaultEnabled, NewMemorySwapCurrentCollector)
 	registerCollector("memory.high", defaultEnabled, NewMemoryHighCollector)
 	registerCollector("memory.stat", defaultDisabled, NewMemoryStatCollector)
+	registerCollector("cpu.pressure", defaultEnabled, NewCpuPressureCollector)
 	registerCollector("cpuset.cpus", defaultEnabled, NewCPUSetCpusCollector)
 	registerCollector("cpuset.cpus.effective", defaultEnabled, NewCPUSetCpusEffectiveCollector)
 	registerCollector("cpu.stat", defaultEnabled, NewCpuStatCollector)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CPU pressure metrics collector now enabled by default.

* **Documentation**
  * Updated documentation with detailed descriptions and tables of default-enabled collectors across Memory, CPU, and I/O categories, providing comprehensive reference for available metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->